### PR TITLE
Makefile: Installation path updated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ GIT_ARCHIVE_TYPE = tar.gz
 prefix       = /usr/local
 datarootdir  = $(prefix)/share
 datadir      = $(datarootdir)
-packagedir   = $(datadir)/$(AUTHOR)/resources/mappings
+packagedir   = $(datadir)/$(AUTHOR)/resources/mapping
 
 # Source & destination folders:
 CMap_CNS1_source = Adobe-CNS1-7


### PR DESCRIPTION
  /usr/local/share/adobe/resources/mapping is the default path now